### PR TITLE
SFT Agent container and supporting infra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL:=bash
 
 aws_profile=default
+aws_profile_mgt_dev=dataworks-management-dev
 aws_region=eu-west-2
 
 default: help
@@ -16,6 +17,7 @@ bootstrap: ## Bootstrap local environment for first use
 	@{ \
 		export AWS_PROFILE=$(aws_profile); \
 		export AWS_REGION=$(aws_region); \
+		export AWS_PROFILE_MGT_DEV=$(aws_profile_mgt_dev); \
 		python3 bootstrap_terraform.py; \
 	}
 	terraform fmt -recursive

--- a/agent-application-config.tpl
+++ b/agent-application-config.tpl
@@ -1,0 +1,41 @@
+sender:
+  routes:
+    - name: DA/Dataworks_UCFS_data
+      source: /data/warehouse/
+      actions:
+        - name: httpRequest
+          properties:
+            destination: https://${destinationIP}:8091/DA/Dataworks_UCFS_data
+      errorFolder: /data/error/warehouse
+      threadPoolSize: 5
+      maxThreadPoolSize: 5
+      deleteOnSend: true
+      filenameRegex: .*
+    - name: DA/Dataworks_UCFS_tactical
+      source: /data/sas/
+      actions:
+        - name: httpRequest
+          properties:
+            destination: https://${destinationIP}:8091/DA/Dataworks_UCFS_tactical
+      errorFolder: /data/error/sas
+      threadPoolSize: 5
+      maxThreadPoolSize: 5
+      deleteOnSend: true
+      filenameRegex: .*
+    - name: DSP/Dataworks_UCFS_data
+      source: /data/RIS/
+      actions:
+        - name: httpRequest
+          properties:
+            destination: https://${destinationIP}:8091/DSP/Dataworks_UCFS_data
+      errorFolder: /data/error/RIS
+      threadPoolSize: 5
+      maxThreadPoolSize: 5
+      deleteOnSend: true
+      filenameRegex: .*
+  retryBehaviour:
+    maximumRedeliveries: 3
+    redeliveryDelay: 600000
+    maximumRedeliveryDelay: 3600000
+    backOffMultiplier: 2
+

--- a/agent-config.tpl
+++ b/agent-config.tpl
@@ -1,0 +1,22 @@
+httpClient:
+  timeout: 3600000ms
+  connectionTimeout: 20000ms
+  connectionRequestTimeout: 20000ms
+
+logging:
+  appenders:
+    - type: console
+      threshold: INFO
+      target: stdout
+      logFormat: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%30.30t] %-30.30c{1} %mdc{} %-5p %m%n"
+    - type: file
+      threshold: INFO
+      logFormat: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%30.30t] %-30.30c{1} %mdc{} %-5p %m%n"
+      currentLogFilename: /var/log/sft/sft-agent.log
+      archivedLogFilenamePattern: /var/log/sft-agent-%d.log.gz
+      archivedFileCount: 7
+      timeZone: UTC
+
+apikey: ${apiKey}
+
+<#include "agent-application-config.yml">

--- a/bootstrap_terraform.py
+++ b/bootstrap_terraform.py
@@ -7,50 +7,33 @@ import os
 import sys
 import yaml
 import json
-import datetime
-from dateutil.tz import tzlocal
 
 
 def main():
     if 'AWS_PROFILE' in os.environ:
         boto3.setup_default_session(profile_name=os.environ['AWS_PROFILE'])
-        secrets_session = boto3.Session(
-            profile_name=os.environ['AWS_PROFILE'])
-    if 'AWS_PROFILE_MGT_DEV' in os.environ:
-        secrets_session = boto3.Session(
-            profile_name=os.environ['AWS_PROFILE_MGT_DEV'])
-    elif 'AWS_SECRETS_ROLE' in os.environ:
-        secrets_session = assumed_role_session(os.environ['AWS_SECRETS_ROLE'])
     if 'AWS_REGION' in os.environ:
-        ssm = boto3.client('ssm', region_name=os.environ['AWS_REGION'])
-        secrets_manager = secrets_session.client(
+        secrets_manager = boto3.client(
             'secretsmanager', region_name=os.environ['AWS_REGION'])
     else:
-        ssm = boto3.client('ssm')
-        secrets_manager = secrets_session.client('secretsmanager')
+        secrets_manager = boto3.client('secretsmanager')
 
     try:
-        parameter = ssm.get_parameter(
-            Name='terraform_bootstrap_config', WithDecryption=False)
-        terraform_secret = secrets_manager.get_secret_value(
+        response = secrets_manager.get_secret_value(
             SecretId="/concourse/dataworks/terraform")
     except botocore.exceptions.ClientError as e:
         error_message = e.response["Error"]["Message"]
         if "The security token included in the request is invalid" in error_message:
-            print("ERROR: Invalid security token used when calling AWS SSM or Secrets Manager. Have you run `aws-sts` recently?")
+            print("ERROR: Invalid security token used when calling AWS Secrets Manager. Have you run `aws-sts` recently?")
         else:
-            print("ERROR: Problem calling AWS SSM or Secrets Manager: {}".format(
+            print("ERROR: Problem calling AWS Secrets Manager: {}".format(
                 error_message))
         sys.exit(1)
 
     config_data = yaml.load(
-        parameter['Parameter']['Value'], Loader=yaml.FullLoader)
+        response['SecretBinary'], Loader=yaml.FullLoader)
     config_data['terraform'] = json.loads(
-        terraform_secret['SecretBinary'])["terraform"]
-    config_data['opsmi'] = json.loads(
-        terraform_secret['SecretBinary'])["opsmi"]
-    config_data['data_egress'] = json.loads(
-        terraform_secret['SecretBinary'])["data_egress"]
+        response['SecretBinary'])["terraform"]
 
     with open('terraform.tf.j2') as in_template:
         template = jinja2.Template(in_template.read())
@@ -61,26 +44,6 @@ def main():
     with open('terraform.tfvars', 'w+') as terraform_tfvars:
         terraform_tfvars.write(template.render(config_data))
     print("Terraform config successfully created")
-
-
-def assumed_role_session(role_arn: str, base_session: botocore.session.Session = None):
-    base_session = base_session or boto3.session.Session()._session
-    fetcher = botocore.credentials.AssumeRoleCredentialFetcher(
-        client_creator=base_session.create_client,
-        source_credentials=base_session.get_credentials(),
-        role_arn=role_arn,
-        extra_args={
-            #    'RoleSessionName': None # set this if you want something non-default
-        }
-    )
-    creds = botocore.credentials.DeferredRefreshableCredentials(
-        method='assume-role',
-        refresh_using=fetcher.fetch_credentials,
-        time_fetcher=lambda: datetime.datetime.now(tzlocal())
-    )
-    botocore_session = botocore.session.Session()
-    botocore_session._credentials = creds
-    return boto3.Session(botocore_session=botocore_session)
 
 
 if __name__ == "__main__":

--- a/bootstrap_terraform.py
+++ b/bootstrap_terraform.py
@@ -7,33 +7,48 @@ import os
 import sys
 import yaml
 import json
+import datetime
+from dateutil.tz import tzlocal
 
 
 def main():
     if 'AWS_PROFILE' in os.environ:
         boto3.setup_default_session(profile_name=os.environ['AWS_PROFILE'])
+    if 'AWS_PROFILE_MGT_DEV' in os.environ:
+        secrets_session = boto3.Session(
+            profile_name=os.environ['AWS_PROFILE_MGT_DEV'])
+    elif 'AWS_SECRETS_ROLE' in os.environ:
+        secrets_session = assumed_role_session(os.environ['AWS_SECRETS_ROLE'])
     if 'AWS_REGION' in os.environ:
-        secrets_manager = boto3.client(
+        ssm = boto3.client('ssm', region_name=os.environ['AWS_REGION'])
+        secrets_manager = secrets_session.client(
             'secretsmanager', region_name=os.environ['AWS_REGION'])
     else:
-        secrets_manager = boto3.client('secretsmanager')
+        ssm = boto3.client('ssm')
+        secrets_manager = secrets_session.client('secretsmanager')
 
     try:
-        response = secrets_manager.get_secret_value(
+        parameter = ssm.get_parameter(
+            Name='terraform_bootstrap_config', WithDecryption=False)
+        terraform_secret = secrets_manager.get_secret_value(
             SecretId="/concourse/dataworks/terraform")
     except botocore.exceptions.ClientError as e:
         error_message = e.response["Error"]["Message"]
         if "The security token included in the request is invalid" in error_message:
-            print("ERROR: Invalid security token used when calling AWS Secrets Manager. Have you run `aws-sts` recently?")
+            print("ERROR: Invalid security token used when calling AWS SSM or Secrets Manager. Have you run `aws-sts` recently?")
         else:
-            print("ERROR: Problem calling AWS Secrets Manager: {}".format(
+            print("ERROR: Problem calling AWS SSM or Secrets Manager: {}".format(
                 error_message))
         sys.exit(1)
 
     config_data = yaml.load(
-        response['SecretBinary'], Loader=yaml.FullLoader)
+        parameter['Parameter']['Value'], Loader=yaml.FullLoader)
     config_data['terraform'] = json.loads(
-        response['SecretBinary'])["terraform"]
+        terraform_secret['SecretBinary'])["terraform"]
+    config_data['opsmi'] = json.loads(
+        terraform_secret['SecretBinary'])["opsmi"]
+    config_data['data_egress'] = json.loads(
+        terraform_secret['SecretBinary'])["data_egress"]
 
     with open('terraform.tf.j2') as in_template:
         template = jinja2.Template(in_template.read())
@@ -44,6 +59,26 @@ def main():
     with open('terraform.tfvars', 'w+') as terraform_tfvars:
         terraform_tfvars.write(template.render(config_data))
     print("Terraform config successfully created")
+
+
+def assumed_role_session(role_arn: str, base_session: botocore.session.Session = None):
+    base_session = base_session or boto3.session.Session()._session
+    fetcher = botocore.credentials.AssumeRoleCredentialFetcher(
+        client_creator=base_session.create_client,
+        source_credentials=base_session.get_credentials(),
+        role_arn=role_arn,
+        extra_args={
+            #    'RoleSessionName': None # set this if you want something non-default
+        }
+    )
+    creds = botocore.credentials.DeferredRefreshableCredentials(
+        method='assume-role',
+        refresh_using=fetcher.fetch_credentials,
+        time_fetcher=lambda: datetime.datetime.now(tzlocal())
+    )
+    botocore_session = botocore.session.Session()
+    botocore_session._credentials = creds
+    return boto3.Session(botocore_session=botocore_session)
 
 
 if __name__ == "__main__":

--- a/bootstrap_terraform.py
+++ b/bootstrap_terraform.py
@@ -14,6 +14,8 @@ from dateutil.tz import tzlocal
 def main():
     if 'AWS_PROFILE' in os.environ:
         boto3.setup_default_session(profile_name=os.environ['AWS_PROFILE'])
+        secrets_session = boto3.Session(
+            profile_name=os.environ['AWS_PROFILE'])
     if 'AWS_PROFILE_MGT_DEV' in os.environ:
         secrets_session = boto3.Session(
             profile_name=os.environ['AWS_PROFILE_MGT_DEV'])

--- a/cluster_ecs.tf
+++ b/cluster_ecs.tf
@@ -86,9 +86,9 @@ resource "aws_autoscaling_group" "data_egress_server" {
 }
 
 resource "aws_launch_template" "data_egress_server" {
-  name                   = local.data_egress_friendly_name
-  image_id               = var.ecs_hardened_ami_id
-  instance_type          = var.data_egress_server_ec2_instance_type[local.environment]
+  name          = local.data_egress_friendly_name
+  image_id      = var.ecs_hardened_ami_id
+  instance_type = var.data_egress_server_ec2_instance_type[local.environment]
   network_interfaces {
     associate_public_ip_address = false
     delete_on_termination       = true

--- a/data-egress_ecs_task.tf
+++ b/data-egress_ecs_task.tf
@@ -23,7 +23,7 @@ data "template_file" "data_egress_definition" {
   template = file("${path.module}/reserved_container_definition.tpl")
   vars = {
     name               = "data-egress"
-    group_name         = "data-egress"
+    group_name         = local.data-egress_group_name
     cpu                = var.fargate_cpu
     image_url          = format("%s:%s", data.terraform_remote_state.management.outputs.dataworks_data_egress_url, var.data_egress_image_version)
     memory             = var.receiver_memory
@@ -34,6 +34,7 @@ data "template_file" "data_egress_definition" {
     log_group          = aws_cloudwatch_log_group.data_egress_cluster.name
     region             = data.aws_region.current.name
     config_bucket      = data.terraform_remote_state.common.outputs.config_bucket.id
+    s3_prefix          = local.data-egress_config_s3_prefix
 
     mount_points = jsonencode([
       {
@@ -134,4 +135,3 @@ resource "aws_service_discovery_private_dns_namespace" "data-egress" {
   vpc  = data.terraform_remote_state.aws_sdx.outputs.vpc.vpc.id
   tags = merge(local.tags, { Name = var.name })
 }
-

--- a/data-egress_sg.tf
+++ b/data-egress_sg.tf
@@ -11,21 +11,6 @@ resource "aws_security_group" "data_egress_service" {
   )
 }
 
-locals {
-  service_security_group_rules = [
-    {
-      name : "VPC endpoints"
-      port : 443
-      destination : data.terraform_remote_state.aws_sdx.outputs.vpc.interface_vpce_sg_id
-    },
-    {
-      name : "Internet proxy endpoints"
-      port : 3128
-      destination : data.terraform_remote_state.aws_sdx.outputs.internet_proxy.sg
-    },
-  ]
-}
-
 resource "aws_security_group_rule" "service_ingress" {
   for_each                 = { for security_group_rule in local.service_security_group_rules : security_group_rule.name => security_group_rule }
   description              = "Allow inbound requests from ${each.value.name}"

--- a/locals.tf
+++ b/locals.tf
@@ -10,25 +10,25 @@ locals {
   }
 
   data_egress_server_asg_min = {
-    development = 1
-    qa          = 1
-    integration = 1
-    preprod     = 1
-    production  = 1
+    development = 0
+    qa          = 0
+    integration = 0
+    preprod     = 0
+    production  = 0
   }
   data_egress_server_asg_desired = {
-    development = 1
-    qa          = 1
-    integration = 1
-    preprod     = 1
-    production  = 1
+    development = 2
+    qa          = 2
+    integration = 2
+    preprod     = 2
+    production  = 2
   }
   data_egress_server_asg_max = {
-    development = 1
-    qa          = 1
-    integration = 1
-    preprod     = 1
-    production  = 1
+    development = 2
+    qa          = 2
+    integration = 2
+    preprod     = 2
+    production  = 2
   }
   data_egress_server_ssmenabled = {
     development = "True"

--- a/locals.tf
+++ b/locals.tf
@@ -86,7 +86,7 @@ locals {
   ]
 
   sft_agent_group_name       = "sft_agent"
-  sft_agent_config_s3_prefix = "monitoring/${local.sft_agent_group_name}"
+  sft_agent_config_s3_prefix = "component/data-egress-sft"
 
   data-egress_group_name       = "data-egress"
   data-egress_config_s3_prefix = "monitoring/${local.data-egress_group_name}"

--- a/locals.tf
+++ b/locals.tf
@@ -71,4 +71,23 @@ locals {
   cw_agent_netstat_metrics_collection_interval          = 60
   dks_endpoint                                          = data.terraform_remote_state.crypto.outputs.dks_endpoint[local.environment]
   dks_fqdn                                              = data.terraform_remote_state.crypto.outputs.dks_fqdn[local.environment]
+
+  service_security_group_rules = [
+    {
+      name : "VPC endpoints"
+      port : 443
+      destination : data.terraform_remote_state.aws_sdx.outputs.vpc.interface_vpce_sg_id
+    },
+    {
+      name : "Internet proxy endpoints"
+      port : 3128
+      destination : data.terraform_remote_state.aws_sdx.outputs.internet_proxy.sg
+    },
+  ]
+
+  sft_agent_group_name       = "sft_agent"
+  sft_agent_config_s3_prefix = "monitoring/${local.sft_agent_group_name}"
+
+  data-egress_group_name       = "data-egress"
+  data-egress_config_s3_prefix = "monitoring/${local.data-egress_group_name}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,3 +8,9 @@ output "security_group" {
   }
 }
 
+output "sft_agent_service" {
+  value = {
+    security_group = aws_security_group.sft_agent_service.id
+  }
+}
+

--- a/reserved_container_definition.tpl
+++ b/reserved_container_definition.tpl
@@ -49,7 +49,7 @@
       },
       {
         "name": join("", [upper(group_name), "_CONFIG_S3_PREFIX"]),
-        "value": "monitoring/${group_name}"
+        "value": s3_prefix
       }
     ],
     [

--- a/sft-agent_ecs_task.tf
+++ b/sft-agent_ecs_task.tf
@@ -1,0 +1,78 @@
+resource "aws_ecs_task_definition" "sft-agent" {
+  family                   = "sft-agent"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  cpu                      = "2048"
+  memory                   = "4096"
+  task_role_arn            = aws_iam_role.sft_agent_task.arn
+  execution_role_arn       = data.terraform_remote_state.common.outputs.ecs_task_execution_role.arn
+  container_definitions    = "[${data.template_file.sft_agent_definition.rendered}]"
+  tags                     = merge(local.tags, { Name = var.name })
+}
+
+data "template_file" "sft_agent_definition" {
+  template = file("${path.module}/reserved_container_definition.tpl")
+  vars = {
+    name               = "sft-agent"
+    group_name         = local.sft_agent_group_name
+    cpu                = var.fargate_cpu
+    image_url          = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_sft_agent_url, var.sft_agent_image_version)
+    memory             = var.receiver_memory
+    memory_reservation = var.fargate_memory
+    user               = "nobody"
+    ports              = jsonencode([parseint(var.sft_agent_port, 10)])
+    ulimits            = jsonencode([])
+    log_group          = aws_cloudwatch_log_group.data_egress_cluster.name
+    region             = data.aws_region.current.name
+    config_bucket      = data.terraform_remote_state.common.outputs.config_bucket.id
+    s3_prefix          = local.sft_agent_config_s3_prefix
+
+    mount_points = jsonencode([
+      //      {
+      //        "container_path" : "/sft-agent",
+      //        "source_volume" : "sft-agent"
+      //      }
+    ])
+
+    environment_variables = jsonencode([
+      {
+        name  = "internet_proxy",
+        value = data.terraform_remote_state.aws_sdx.outputs.internet_proxy.host
+      },
+      {
+        name  = "non_proxied_endpoints",
+        value = join(",", data.terraform_remote_state.aws_sdx.outputs.vpc.no_proxy_list)
+      },
+      {
+        name  = "AWS_REGION",
+        value = var.region
+      },
+      {
+        name : "AWS_DEFAULT_REGION",
+        value : var.region
+      }
+
+    ])
+  }
+}
+
+resource "aws_ecs_service" "sft-agent" {
+  name            = "sft-agent"
+  cluster         = aws_ecs_cluster.data_egress_cluster.id
+  task_definition = aws_ecs_task_definition.sft-agent.arn
+  desired_count   = 1
+  launch_type     = "EC2"
+
+
+  network_configuration {
+    security_groups = [aws_security_group.sft_agent_service.id]
+    subnets         = data.terraform_remote_state.aws_sdx.outputs.subnet_sdx_connectivity.*.id
+  }
+
+  service_registries {
+    registry_arn   = aws_service_discovery_service.data-egress.arn
+    container_name = "sft-agent"
+  }
+
+  tags = merge(local.tags, { Name = var.name })
+}

--- a/sft-agent_ecs_task.tf
+++ b/sft-agent_ecs_task.tf
@@ -19,7 +19,7 @@ data "template_file" "sft_agent_definition" {
     image_url          = format("%s:%s", data.terraform_remote_state.management.outputs.ecr_sft_agent_url, var.sft_agent_image_version)
     memory             = var.receiver_memory
     memory_reservation = var.fargate_memory
-    user               = "nobody"
+    user               = "root"
     ports              = jsonencode([parseint(var.sft_agent_port, 10)])
     ulimits            = jsonencode([])
     log_group          = aws_cloudwatch_log_group.data_egress_cluster.name
@@ -50,6 +50,10 @@ data "template_file" "sft_agent_definition" {
       {
         name : "AWS_DEFAULT_REGION",
         value : var.region
+      },
+      {
+        name : "LOG_LEVEL",
+        value : "DEBUG"
       }
 
     ])

--- a/sft-agent_ecs_task.tf
+++ b/sft-agent_ecs_task.tf
@@ -2,8 +2,8 @@ resource "aws_ecs_task_definition" "sft-agent" {
   family                   = "sft-agent"
   network_mode             = "awsvpc"
   requires_compatibilities = ["EC2"]
-  cpu                      = "2048"
-  memory                   = "4096"
+  cpu                      = "4096"
+  memory                   = "8192"
   task_role_arn            = aws_iam_role.sft_agent_task.arn
   execution_role_arn       = data.terraform_remote_state.common.outputs.ecs_task_execution_role.arn
   container_definitions    = "[${data.template_file.sft_agent_definition.rendered}]"

--- a/sft-agent_iam.tf
+++ b/sft-agent_iam.tf
@@ -29,8 +29,8 @@ data "aws_iam_policy_document" "sft_agent_task" {
   }
 
   statement {
-    sid = "AllowKMSDecrypt"
-    actions = ["kms:Decrypt"]
+    sid       = "AllowKMSDecrypt"
+    actions   = ["kms:Decrypt"]
     resources = [data.terraform_remote_state.common.outputs.config_bucket_cmk.arn]
   }
 
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "sft_agent_task" {
     resources = [
       "${data.terraform_remote_state.common.outputs.config_bucket.arn}/${aws_s3_bucket_object.data_egress_sft_agent_config.key}",
       "${data.terraform_remote_state.common.outputs.config_bucket.arn}/${aws_s3_bucket_object.data_egress_sft_agent_application_config.key}",
-      ]
+    ]
   }
 
   statement {

--- a/sft-agent_iam.tf
+++ b/sft-agent_iam.tf
@@ -1,0 +1,50 @@
+resource "aws_iam_role" "sft_agent_task" {
+  name               = "SFTAgentTask"
+  assume_role_policy = data.aws_iam_policy_document.sft_agent_task_assume_role.json
+}
+
+data "aws_iam_policy_document" "sft_agent_task_assume_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "sft_agent_task" {
+
+  statement {
+    sid = "PullSFTAgentImageECR"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+    ]
+    resources = [data.terraform_remote_state.management.outputs.sft_agent_ecr_repository.arn]
+  }
+
+  statement {
+    sid = "PullSFTAgentConfigS3"
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = ["${data.terraform_remote_state.common.outputs.config_bucket.arn}/${local.sft_agent_config_s3_prefix}"]
+  }
+
+}
+
+resource "aws_iam_policy" "sft_agent_task" {
+  name        = "SFTAgentTask"
+  description = "Custom policy for the sft agent task"
+  policy      = data.aws_iam_policy_document.sft_agent_task.json
+}
+resource "aws_iam_role_policy_attachment" "sft_agent" {
+  role       = aws_iam_role.sft_agent_task.name
+  policy_arn = aws_iam_policy.sft_agent_task.arn
+}
+

--- a/sft-agent_iam.tf
+++ b/sft-agent_iam.tf
@@ -29,13 +29,32 @@ data "aws_iam_policy_document" "sft_agent_task" {
   }
 
   statement {
+    sid = "AllowKMSDecrypt"
+    actions = ["kms:Decrypt"]
+    resources = [data.terraform_remote_state.common.outputs.config_bucket_cmk.arn]
+  }
+
+  statement {
     sid = "PullSFTAgentConfigS3"
     actions = [
       "s3:GetObject"
     ]
-    resources = ["${data.terraform_remote_state.common.outputs.config_bucket.arn}/${local.sft_agent_config_s3_prefix}"]
+    resources = [
+      "${data.terraform_remote_state.common.outputs.config_bucket.arn}/${aws_s3_bucket_object.data_egress_sft_agent_config.key}",
+      "${data.terraform_remote_state.common.outputs.config_bucket.arn}/${aws_s3_bucket_object.data_egress_sft_agent_application_config.key}",
+      ]
   }
 
+  statement {
+    sid = "ListConfigBucket"
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      data.terraform_remote_state.common.outputs.config_bucket.arn,
+      "${data.terraform_remote_state.common.outputs.config_bucket.arn}/*"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "sft_agent_task" {

--- a/sft-agent_s3_config.tf
+++ b/sft-agent_s3_config.tf
@@ -1,0 +1,27 @@
+resource "aws_s3_bucket_object" "data_egress_sft_agent_config" {
+  bucket     = data.terraform_remote_state.common.outputs.config_bucket.id
+  key        = "component/data-egress-sft/agent-config.yml"
+  content    = data.template_file.data_egress_sft_agent_config_tpl.rendered
+  kms_key_id = data.terraform_remote_state.common.outputs.config_bucket_cmk.arn
+}
+
+resource "aws_s3_bucket_object" "data_egress_sft_agent_application_config" {
+  bucket     = data.terraform_remote_state.common.outputs.config_bucket.id
+  key        = "component/data-egress-sft/agent-application-config.yml"
+  content    = data.template_file.data_egress_sft_agent_application_config_tpl.rendered
+  kms_key_id = data.terraform_remote_state.common.outputs.config_bucket_cmk.arn
+}
+
+data "template_file" "data_egress_sft_agent_config_tpl" {
+  template = file("${path.module}/agent-config.tpl")
+  vars = {
+    apiKey = var.sft_agent_api_key
+  }
+}
+
+data "template_file" "data_egress_sft_agent_application_config_tpl" {
+  template = file("${path.module}/agent-application-config.tpl")
+  vars = {
+    destinationIP = var.sft_agent_destination_ip
+  }
+}

--- a/sft-agent_s3_config.tf
+++ b/sft-agent_s3_config.tf
@@ -1,13 +1,13 @@
 resource "aws_s3_bucket_object" "data_egress_sft_agent_config" {
   bucket     = data.terraform_remote_state.common.outputs.config_bucket.id
-  key        = "component/data-egress-sft/agent-config.yml"
+  key        = "${local.sft_agent_config_s3_prefix}/agent-config.yml"
   content    = data.template_file.data_egress_sft_agent_config_tpl.rendered
   kms_key_id = data.terraform_remote_state.common.outputs.config_bucket_cmk.arn
 }
 
 resource "aws_s3_bucket_object" "data_egress_sft_agent_application_config" {
   bucket     = data.terraform_remote_state.common.outputs.config_bucket.id
-  key        = "component/data-egress-sft/agent-application-config.yml"
+  key        = "${local.sft_agent_config_s3_prefix}/agent-application-config.yml"
   content    = data.template_file.data_egress_sft_agent_application_config_tpl.rendered
   kms_key_id = data.terraform_remote_state.common.outputs.config_bucket_cmk.arn
 }

--- a/sft-agent_s3_config.tf
+++ b/sft-agent_s3_config.tf
@@ -15,13 +15,13 @@ resource "aws_s3_bucket_object" "data_egress_sft_agent_application_config" {
 data "template_file" "data_egress_sft_agent_config_tpl" {
   template = file("${path.module}/agent-config.tpl")
   vars = {
-    apiKey = var.sft_agent_api_key
+    apiKey = local.data_egress[local.environment].sft_agent_api_key
   }
 }
 
 data "template_file" "data_egress_sft_agent_application_config_tpl" {
   template = file("${path.module}/agent-application-config.tpl")
   vars = {
-    destinationIP = var.sft_agent_destination_ip
+    destinationIP = local.data_egress[local.environment].sft_agent_destination_ip
   }
 }

--- a/sft-agent_sg.tf
+++ b/sft-agent_sg.tf
@@ -1,0 +1,42 @@
+resource "aws_security_group" "sft_agent_service" {
+  name        = "sft_agent_service"
+  description = "Control access to and from data egress service"
+  vpc_id      = data.terraform_remote_state.aws_sdx.outputs.vpc.vpc.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "sft_agent_service"
+    }
+  )
+}
+
+resource "aws_security_group_rule" "sft_agent_service_s3_https" {
+  description       = "Access to S3 https"
+  type              = "egress"
+  prefix_list_ids   = [data.terraform_remote_state.aws_sdx.outputs.vpc.prefix_list_ids.s3]
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  security_group_id = aws_security_group.sft_agent_service.id
+}
+
+resource "aws_security_group_rule" "sft_agent_service_s3_http" {
+  description       = "Access to S3 http"
+  type              = "egress"
+  prefix_list_ids   = [data.terraform_remote_state.aws_sdx.outputs.vpc.prefix_list_ids.s3]
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  security_group_id = aws_security_group.sft_agent_service.id
+}
+
+resource "aws_security_group_rule" "sft_agent_service_to_crown" {
+  description       = "Allow SFT agent to access crown"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 8091
+  to_port           = 8091
+  security_group_id = aws_security_group.sft_agent_service.id
+  cidr_blocks       = [data.terraform_remote_state.aws_sdx.outputs.vpc.vpc.cidr_block]
+}

--- a/sft-agent_sg.tf
+++ b/sft-agent_sg.tf
@@ -35,8 +35,8 @@ resource "aws_security_group_rule" "sft_agent_service_to_crown" {
   description       = "Allow SFT agent to access crown"
   type              = "egress"
   protocol          = "tcp"
-  from_port         = 8091
-  to_port           = 8091
+  from_port         = var.sft_agent_port
+  to_port           = var.sft_agent_port
   security_group_id = aws_security_group.sft_agent_service.id
   cidr_blocks       = [data.terraform_remote_state.aws_sdx.outputs.vpc.vpc.cidr_block]
 }

--- a/terraform.tf.j2
+++ b/terraform.tf.j2
@@ -67,6 +67,14 @@ locals {
              {{ key }} = "{{ value }}"{% endfor %}
          } {%- endfor %}
      }
+
+    data_egress = {
+     {%- for environment, ranges in data_egress.items() %}
+         {{ environment }} = {
+           {%- for key, value in ranges.items() %}
+             {{ key }} = "{{ value }}"{% endfor %}
+         } {%- endfor %}
+     }
 }
 
 data "terraform_remote_state" "common" {

--- a/terraform.tfvars.j2
+++ b/terraform.tfvars.j2
@@ -1,2 +1,4 @@
 assume_role              = "administrator"
 ecs_hardened_ami_id = "ami-049bba1a08b31ff8e"
+sft_agent_port      = "9091"
+sft_agent_image_version = "0.0.1"

--- a/terraform.tfvars.j2
+++ b/terraform.tfvars.j2
@@ -1,4 +1,4 @@
 assume_role              = "administrator"
 ecs_hardened_ami_id      = "ami-049bba1a08b31ff8e"
 sft_agent_port           = "9091"
-sft_agent_image_version  = "0.0.1"
+sft_agent_image_version  = "0.0.2"

--- a/terraform.tfvars.j2
+++ b/terraform.tfvars.j2
@@ -1,4 +1,6 @@
 assume_role              = "administrator"
-ecs_hardened_ami_id = "ami-049bba1a08b31ff8e"
-sft_agent_port      = "9091"
-sft_agent_image_version = "0.0.1"
+ecs_hardened_ami_id      = "ami-049bba1a08b31ff8e"
+sft_agent_port           = "9091"
+sft_agent_image_version  = "0.0.1"
+sft_agent_destination_ip = {{sft_agent_destination_ip}}
+sft_agent_api_key        = {{sft_agent_api_key}}

--- a/terraform.tfvars.j2
+++ b/terraform.tfvars.j2
@@ -2,5 +2,3 @@ assume_role              = "administrator"
 ecs_hardened_ami_id      = "ami-049bba1a08b31ff8e"
 sft_agent_port           = "9091"
 sft_agent_image_version  = "0.0.1"
-sft_agent_destination_ip = {{sft_agent_destination_ip}}
-sft_agent_api_key        = {{sft_agent_api_key}}

--- a/terraform.tfvars.j2
+++ b/terraform.tfvars.j2
@@ -1,4 +1,4 @@
 assume_role              = "administrator"
 ecs_hardened_ami_id      = "ami-049bba1a08b31ff8e"
 sft_agent_port           = "9091"
-sft_agent_image_version  = "0.0.2"
+sft_agent_image_version  = "0.0.3"

--- a/variables.tf
+++ b/variables.tf
@@ -101,13 +101,3 @@ variable "sft_agent_image_version" {
   description = "image version for the SFT agent"
   type        = string
 }
-
-variable "sft_agent_destination_ip" {
-  description = "destination IP for the SFT agent to send to"
-  type        = string
-}
-
-variable "sft_agent_api_key" {
-  description = "API key for the SFT agent"
-  type        = string
-}

--- a/variables.tf
+++ b/variables.tf
@@ -94,7 +94,7 @@ variable "parent_domain_name" {
 variable "sft_agent_port" {
   description = "port for accessing the SFT agent"
   type        = string
-  default     = "9091"
+  default     = "8091"
 }
 
 variable "sft_agent_image_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,11 +12,11 @@ variable "region" {
 variable "data_egress_server_ec2_instance_type" {
   type = map(string)
   default = {
-    development = "m5.large"
-    qa          = "m5.large"
-    integration = "m5.large"
-    preprod     = "m5.large"
-    production  = "m5.large"
+    development = "m5.xlarge"
+    qa          = "m5.xlarge"
+    integration = "m5.xlarge"
+    preprod     = "m5.xlarge"
+    production  = "m5.xlarge"
   }
 }
 variable "data_egress_server_ebs_volume_size" {
@@ -99,5 +99,15 @@ variable "sft_agent_port" {
 
 variable "sft_agent_image_version" {
   description = "image version for the SFT agent"
+  type        = string
+}
+
+variable "sft_agent_destination_ip" {
+  description = "destination IP for the SFT agent to send to"
+  type        = string
+}
+
+variable "sft_agent_api_key" {
+  description = "API key for the SFT agent"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -97,4 +97,8 @@ variable "sft_agent_port" {
   default     = "8091"
 }
 
-variable "sft_agent_image_version" {}
+variable "sft_agent_image_version" {
+  description = "image version for the SFT agent"
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,13 @@ variable "parent_domain_name" {
   default     = "dataworks.dwp.gov.uk"
 }
 
+variable "sft_agent_port" {
+  description = "port for accessing the SFT agent"
+  type        = string
+  default     = "9091"
+}
+
+variable "sft_agent_image_version" {
+  description = "image version for the SFT agent"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -97,8 +97,4 @@ variable "sft_agent_port" {
   default     = "8091"
 }
 
-variable "sft_agent_image_version" {
-  description = "image version for the SFT agent"
-  type        = string
-  default     = "0.0.3"
-}
+variable "sft_agent_image_version" {}

--- a/variables.tf
+++ b/variables.tf
@@ -100,4 +100,5 @@ variable "sft_agent_port" {
 variable "sft_agent_image_version" {
   description = "image version for the SFT agent"
   type        = string
+  default     = "0.0.3"
 }


### PR DESCRIPTION
- Create an SFT Agent service and task on the data-egress cluster.
- Push SFT agent configuration files to S3 with environment specific parameters acquired through secrets manager values.